### PR TITLE
restore original function

### DIFF
--- a/implementation.js
+++ b/implementation.js
@@ -4,23 +4,25 @@ var recentWindow;
 
 var myapi = class extends ExtensionCommon.ExtensionAPI {
    getAPI(context) {
+      let self = this;
+      
       return {
          myapi: {
             async hidelocalfolder() {
-               recentWindow = Services.wm.getMostRecentWindow("mail:3pane");
-               if (recentWindow) {
-                  let f = recentWindow.gFolderTreeView._rebuild;
-                  recentWindow.gFolderTreeView._rebuild = function(){
-                     f.call(recentWindow.gFolderTreeView);
+               self.recentWindow = Services.wm.getMostRecentWindow("mail:3pane");
+               if (self.recentWindow) {
+                  self.recentWindow.hideLocalFolderBackup = self.recentWindow.gFolderTreeView._rebuild;
+                  self.recentWindow.gFolderTreeView._rebuild = function(){
+                     self.recentWindow.hideLocalFolderBackup.call(self.recentWindow.gFolderTreeView);
                      cleanTree();
                   };
-                  recentWindow.gFolderTreeView._rebuild();
+                  self.recentWindow.gFolderTreeView._rebuild();
 
                   function cleanTree() {
-                     for(let i = recentWindow.gFolderTreeView._rowMap.length -1; i >= 0 ; i--){
-                        if(recentWindow.gFolderTreeView._rowMap[i]._folder.hostname == 'Local Folders'){
-                           recentWindow.gFolderTreeView._rowMap.splice(i, 1);
-                           recentWindow.gFolderTreeView._tree.rowCountChanged(i, -1);
+                     for(let i = self.recentWindow.gFolderTreeView._rowMap.length -1; i >= 0 ; i--){
+                        if(self.recentWindow.gFolderTreeView._rowMap[i]._folder.hostname == 'Local Folders'){
+                           self.recentWindow.gFolderTreeView._rowMap.splice(i, 1);
+                           self.recentWindow.gFolderTreeView._tree.rowCountChanged(i, -1);
                         }
                      }
                   }
@@ -30,12 +32,14 @@ var myapi = class extends ExtensionCommon.ExtensionAPI {
       };
    }
 
-  onShutdown(isAppShutdown) {
-    if (isAppShutdown) {
-      return;
-    }
-    recentWindow.alert("Local Folders will be visible again after restart of Thunderbird.");
-    Services.obs.notifyObservers(null, "startupcache-invalidate", null);
-  }
+   onShutdown(isAppShutdown) {    
+      // This is called when the add-on or Thunderbird itself is shutting down
+      if (isAppShutdown) {
+         return;
+      }
+      this.recentWindow.gFolderTreeView._rebuild = this.recentWindow.hideLocalFolderBackup;
+      this.recentWindow.gFolderTreeView._rebuild();
+      Services.obs.notifyObservers(null, "startupcache-invalidate", null);
+   }
 
 };


### PR DESCRIPTION
This makes a backup of the function you manipulate and restores the original function on shutdown.
Ping back if anything is unclear.

This is still not final, as we have to deal with multiple main windows to do it right and I will send a PR for that later. This next PR will also follow more the webextension appoach by not using getMostRecentWindow but use the windows API to grab the window.