### PR TITLE
Make this a proper WebExtension

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,1 +1,27 @@
-browser.myapi.hidelocalfolder();
+
+// function to hide the local folder in the given main window (if it is a normal main window)
+function hideLocalFolder(window) {
+	if (window.type != "normal")
+		return;
+	
+	// hide local folders for the given window
+	messenger.myapi.hidelocalfolder(window.id);
+}
+
+// register a event listener for newly opened windows, to
+// automatically call hideLocalFolders() for them
+messenger.windows.onCreated.addListener(hideLocalFolder);
+
+
+// run thru all already opened main windows (type = normal) and hide local folders
+// this will take care of all windows already open while the add-on is being installed or
+// activated during the runtime of Thunderbird.
+async function init() {
+	let windows = await messenger.windows.getAll({windowTypes: ["normal"]});
+	for (let window of windows) {
+		hideLocalFolder(window);
+	}
+}
+
+// run init()
+init();

--- a/schema.json
+++ b/schema.json
@@ -6,7 +6,12 @@
         "name": "hidelocalfolder",
         "type": "function",
         "async": true,
-        "parameters": []
+        "parameters": [
+          {
+            "name": "windowId",
+            "type": "integer"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
This PR moves the logic of this add-on into the background script and uses the windows API to get the window which should be manipulated. The API is now able to handle multiple windows and is a more generic API.

This is now a proper WebExtension, using custom Experiment APIs only for things not available via built-in APIs.

May I use this add-on as a second example in this topic box thread?
https://thunderbird.topicbox.com/groups/addons/Tb635d04ab79cafe7/restricting-usage-of-experiments-in-new-add-ons-webextension-api-have-to-be-used-where-possible-and-experiments-must-not-include-the-main-logic