### PR TITLE
Fix 'requestedWindow.gFolderTreeView._tree is null' received after upgrade to tb 91.5.0 linux

### DIFF
--- a/implementation.js
+++ b/implementation.js
@@ -32,7 +32,8 @@ var myapi = class extends ExtensionCommon.ExtensionAPI {
                   for(let i = requestedWindow.gFolderTreeView._rowMap.length -1; i >= 0 ; i--){
                      if(requestedWindow.gFolderTreeView._rowMap[i]._folder.hostname == 'Local Folders'){
                         requestedWindow.gFolderTreeView._rowMap.splice(i, 1);
-                        requestedWindow.gFolderTreeView._tree.rowCountChanged(i, -1);
+                        if (requestedWindow.gFolderTreeView._tree !== null)
+                          requestedWindow.gFolderTreeView._tree.rowCountChanged(i, -1);
                      }
                   }
                }


### PR DESCRIPTION
'requestedWindow.gFolderTreeView._tree is null' received after upgrade to tb 91.5.0 linux. Resulted in empty folder tree window - and so empty all windows - on tb startup. This change allows tb to start up and then removes the local folders briefly after start.